### PR TITLE
대용량 데이터 처리 성능 개선

### DIFF
--- a/_tracking/tracking/build.gradle
+++ b/_tracking/tracking/build.gradle
@@ -24,7 +24,6 @@ dependencies {
 	testImplementation 'org.projectlombok:lombok:1.18.28'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-
 }
 
 tasks.named('test') {

--- a/_tracking/tracking/src/main/java/com/example/tracking/Controller/TrackingController.java
+++ b/_tracking/tracking/src/main/java/com/example/tracking/Controller/TrackingController.java
@@ -51,4 +51,5 @@ public class TrackingController {
     public void nextDay(){
         this.trackingService.nextDay();
     }
+
 }

--- a/_tracking/tracking/src/main/java/com/example/tracking/Repository/DailyBulkRepository.java
+++ b/_tracking/tracking/src/main/java/com/example/tracking/Repository/DailyBulkRepository.java
@@ -1,0 +1,53 @@
+package com.example.tracking.Repository;
+
+import com.example.tracking.Entity.Daily;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+@Repository @RequiredArgsConstructor
+public class DailyBulkRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void saveAll(List<Daily> dailyList){
+        String sql = "INSERT INTO daily (url, today_hit, total_hit) VALUES (?, ?, ?)";
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setString(1, dailyList.get(i).getUrl());
+                ps.setString(2, dailyList.get(i).getTodayHit().toString());
+                ps.setString(3, dailyList.get(i).getTotalHit().toString());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return dailyList.size();
+            }
+        });
+    }
+
+    @Transactional
+    public void updateAll(List<Daily> dailyList){
+        String sql = "UPDATE daily SET today_hit=? WHERE url_id=?";
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setString(1, dailyList.get(i).getTodayHit().toString());
+                ps.setString(2, dailyList.get(i).getUrlId().toString());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return dailyList.size();
+            }
+        });
+
+    }
+}

--- a/_tracking/tracking/src/main/java/com/example/tracking/Repository/DailyRepository.java
+++ b/_tracking/tracking/src/main/java/com/example/tracking/Repository/DailyRepository.java
@@ -1,10 +1,12 @@
 package com.example.tracking.Repository;
 
 import com.example.tracking.Entity.Daily;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DailyRepository extends JpaRepository<Daily, Integer> {
@@ -12,4 +14,6 @@ public interface DailyRepository extends JpaRepository<Daily, Integer> {
 
     @Query(value = "select d from Daily d left join fetch d.history where d.url=:url")
     public Optional<Daily> findByUrlWithHistory(@Param("url") String url);
+
+    List<Daily> findAllBy(PageRequest pageRequest);
 }

--- a/_tracking/tracking/src/main/java/com/example/tracking/Repository/HistoryBulkRepository.java
+++ b/_tracking/tracking/src/main/java/com/example/tracking/Repository/HistoryBulkRepository.java
@@ -1,0 +1,35 @@
+package com.example.tracking.Repository;
+
+import com.example.tracking.Entity.History;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+@Repository @RequiredArgsConstructor
+public class HistoryBulkRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void saveAll(List<History> historyList){
+        String sql = "INSERT INTO history (url_id, hit, date) VALUES (?, ?, ?)";
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setString(1, historyList.get(i).getDaily().getUrlId().toString());
+                ps.setString(2, historyList.get(i).getHit().toString());
+                ps.setString(3, historyList.get(i).getDate().toString());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return historyList.size();
+            }
+        });
+    }
+}

--- a/_tracking/tracking/src/main/java/com/example/tracking/Service/TrackingService.java
+++ b/_tracking/tracking/src/main/java/com/example/tracking/Service/TrackingService.java
@@ -71,8 +71,10 @@ public class TrackingService {
     public void nextDay(){
         int i = 0;
         while(true) {
-            //전체 오늘의 데이터 불러오기
+            //쪼개진 오늘의 데이터 불러오기
             List<Daily> dlist = this.dailyRepository.findAllBy(PageRequest.of(i, 10000));
+
+            //페이지가 비었으면 모두 확인한 것으로 종료
             if(dlist.size()==0)
                 break;
 
@@ -87,6 +89,7 @@ public class TrackingService {
             this.historyBulkRepository.saveAll(hlist);
             this.dailyBulkRepository.updateAll(dlist);
 
+            //페이지 인덱스 증가
             i++;
         }
     }

--- a/_tracking/tracking/src/test/java/com/example/tracking/DailyBulkRepositoryTest.java
+++ b/_tracking/tracking/src/test/java/com/example/tracking/DailyBulkRepositoryTest.java
@@ -1,0 +1,61 @@
+package com.example.tracking;
+
+import com.example.tracking.Entity.Daily;
+import com.example.tracking.Repository.DailyBulkRepository;
+import com.example.tracking.Repository.DailyRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Sql(scripts = "/truncate.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+public class DailyBulkRepositoryTest {
+    @Autowired
+    private DailyBulkRepository dailyBulkRepository;
+    @Autowired
+    private DailyRepository dailyRepository;
+
+    @Test
+    public void bulkInsertTest(){
+        //데이터 저장
+        List<Daily> dlist = new ArrayList<>();
+        for(int i = 0; i < 100; i++) {
+            dlist.add(new Daily("www." + i +".com", 1, 1L));
+        }
+        this.dailyBulkRepository.saveAll(dlist);
+
+        //개수 및 값 확인
+        List<Daily> dlist2 = this.dailyRepository.findAll();
+        assertEquals(100, dlist2.size());
+        assertEquals(1, dlist2.get(0).getTodayHit());
+    }
+
+    @Test
+    public void bulkUpdateTest(){
+        //데이터 저장
+        List<Daily> dlist = new ArrayList<>();
+        for(int i = 0; i < 100; i++) {
+            dlist.add(new Daily("www." + i +".com", 1, 1L));
+        }
+        this.dailyBulkRepository.saveAll(dlist);
+
+        //데이터 값 업데이트
+        List<Daily> dlist2 = this.dailyRepository.findAll();
+        for(Daily d: dlist2)
+            d.setTodayHit(0);
+        this.dailyBulkRepository.updateAll(dlist2);
+
+        //개수 및 값 확인
+        List<Daily> dlist3 = this.dailyRepository.findAll();
+        assertEquals(100, dlist3.size());
+        assertEquals(0, dlist3.get(0).getTodayHit());
+    }
+}

--- a/_tracking/tracking/src/test/java/com/example/tracking/DailyRepositoryTest.java
+++ b/_tracking/tracking/src/test/java/com/example/tracking/DailyRepositoryTest.java
@@ -2,15 +2,19 @@ package com.example.tracking;
 
 import com.example.tracking.Entity.Daily;
 import com.example.tracking.Entity.History;
+import com.example.tracking.Repository.DailyBulkRepository;
 import com.example.tracking.Repository.DailyRepository;
 import com.example.tracking.Repository.HistoryRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -20,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class DailyRepositoryTest {
     @Autowired
     private DailyRepository dailyRepository;
+    @Autowired
+    private DailyBulkRepository dailyBulkRepository;
     @Autowired
     private HistoryRepository historyRepository;
 
@@ -47,5 +53,22 @@ public class DailyRepositoryTest {
         //존재하지 않는 url
         od = this.dailyRepository.findByUrlWithHistory("https%3A%2F%2Fwww.google.com");
         assertFalse(od.isPresent());
+    }
+
+    @Test
+    public void findAllByTest(){
+        //데이터 저장
+        List<Daily> dlist = new ArrayList<>();
+        for(int i = 0; i < 100; i++) {
+            dlist.add(new Daily("www." + i +".com", 1, 1L));
+        }
+        this.dailyBulkRepository.saveAll(dlist);
+
+        //페이징으로 불러오기
+        List<Daily> dlist2 = this.dailyRepository.findAllBy(PageRequest.of(0, 10));
+
+        //길이 및 값 확인
+        assertEquals(10, dlist2.size());
+        assertEquals("www.0.com", dlist2.get(0).getUrl());
     }
 }

--- a/_tracking/tracking/src/test/java/com/example/tracking/HistoryBulkRepositoryTest.java
+++ b/_tracking/tracking/src/test/java/com/example/tracking/HistoryBulkRepositoryTest.java
@@ -1,0 +1,57 @@
+package com.example.tracking;
+
+import com.example.tracking.Entity.Daily;
+import com.example.tracking.Entity.History;
+import com.example.tracking.Repository.DailyBulkRepository;
+import com.example.tracking.Repository.DailyRepository;
+import com.example.tracking.Repository.HistoryBulkRepository;
+import com.example.tracking.Repository.HistoryRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Sql(scripts = "/truncate.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+public class HistoryBulkRepositoryTest {
+    @Autowired
+    private DailyRepository dailyRepository;
+    @Autowired
+    private HistoryRepository historyRepository;
+    @Autowired
+    private DailyBulkRepository dailyBulkRepository;
+    @Autowired
+    private HistoryBulkRepository historyBulkRepository;
+
+    @Test
+    public void bulkInsertTest(){
+        //데일리 데이터 저장
+        List<Daily> dlist = new ArrayList<>();
+        for(int i = 0; i < 100; i++) {
+            dlist.add(new Daily("www." + i +".com", 1, 2L));
+        }
+        this.dailyBulkRepository.saveAll(dlist);
+
+        //저장된 데일리 데이터 불러오기
+        List<Daily> dlist2 = this.dailyRepository.findAll();
+
+        //데일리 데이터마다 하나의 히스토리 데이터 생성 및 저장
+        List<History> hlist = new ArrayList<>();
+        for(Daily d: dlist2)
+            hlist.add(new History(d, LocalDate.now(), 1));
+        this.historyBulkRepository.saveAll(hlist);
+
+        //히스토리 데이터 개수 및 값 확인
+        List<History> hlist2 = this.historyRepository.findAll();
+        assertEquals(100, hlist2.size());
+        assertEquals(1, hlist2.get(0).getHit());
+    }
+}

--- a/_tracking/tracking/src/test/java/com/example/tracking/TrackingServiceTest.java
+++ b/_tracking/tracking/src/test/java/com/example/tracking/TrackingServiceTest.java
@@ -4,7 +4,9 @@ import com.example.tracking.DTO.HistoryDTO;
 import com.example.tracking.DTO.HitsDTO;
 import com.example.tracking.Entity.Daily;
 import com.example.tracking.Entity.History;
+import com.example.tracking.Repository.DailyBulkRepository;
 import com.example.tracking.Repository.DailyRepository;
+import com.example.tracking.Repository.HistoryBulkRepository;
 import com.example.tracking.Repository.HistoryRepository;
 import com.example.tracking.Service.TrackingService;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +17,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -27,11 +31,16 @@ public class TrackingServiceTest {
     private DailyRepository dailyRepository;
     @Autowired
     private HistoryRepository historyRepository;
+    @Autowired
+    private DailyBulkRepository dailyBulkRepository;
+    @Autowired
+    private HistoryBulkRepository historyBulkRepository;
     private TrackingService trackingService;
 
     @BeforeEach
     public void beforeEach(){
-        this.trackingService = new TrackingService(this.dailyRepository, this.historyRepository);
+        this.trackingService = new TrackingService(this.dailyRepository, this.historyRepository,
+                                                    this.dailyBulkRepository, this.historyBulkRepository);
     }
 
     @Test
@@ -118,5 +127,20 @@ public class TrackingServiceTest {
         assertEquals(0, od.get().getTodayHit());
         assertEquals(3, od.get().getHistory().size());
         assertEquals(6, od.get().getHistory().get(2).getHit());
+    }
+
+    public void nextDayTestWithLargeData(){
+        //데이터 저장
+        List<Daily> dailyList = new ArrayList<>();
+        for(int i = 0; i < 10000; i++) {
+            dailyList.add(new Daily("www." + i +".com", 1, 1L));
+        }
+        dailyBulkRepository.saveAll(dailyList);
+
+        //실행 시간 출력
+        long start = System.currentTimeMillis();
+        this.trackingService.nextDay();
+        long end = System.currentTimeMillis();
+        System.out.println((double)(end-start)/1000 + "seconds");
     }
 }


### PR DESCRIPTION
- 기존에 대용량 데이터에서 데이터를 저장할 때마다 하나의 쿼리를 날려 속도가 느려지는 문제가 발생
- 데이터를 한 번에 모두 읽어오고 한 번에 저장하는 방식의 경우 데이터가 너무 많아지면 메모리 초과가 발생할 수 있기 때문에 일정하게 쪼개어 읽어오고 저장하는 방식을 사용
- 일정량을 쪼개 읽어오는 방법으로 mybatis, jpa paging, stream 등이 있는데 현재 orm을 jpa로 사용하고 있고 일정량 씩 가져오기 때문에 jpa paging을 사용. count로 인한 성능 저하를 막기 위해 list 형식으로 받아옴
- 한 번에 저장하는 방식으로는 pk 생성 방식으로 인해 jpa batch update가 불가하므로 jdbctemplete의 batch update를 사용

10000개 데이터 테스트에서 24초 -> 2.541초로 성능 개선